### PR TITLE
Give example for List.TransformMany.md

### DIFF
--- a/docs/List/List.TransformMany.md
+++ b/docs/List/List.TransformMany.md
@@ -8,3 +8,11 @@ Returns a list whose elements are projected from the input list. The collectionT
     The resultTransform projects the shape of the result and has the signature (x as Any, y as Any) => ... where x is the element in list and y is the element obtained by applying the collectionTransform to that element.
 # Category 
 List.Transformation functions
+# Examples 
+Add 1 to each value in the list {1, 2}.
+```
+List.TransformMany({2, 3}, (value) => {value + 1}, (oldValue, newValue) => oldValue * newValue)
+```
+> {6, 12}
+
+***


### PR DESCRIPTION
I have added a simple example of `List.TransformMany(...)` to illustrate how it works.